### PR TITLE
修复 oldestPeer 为空导致的 Panic

### DIFF
--- a/biz/services/peer/local/local.go
+++ b/biz/services/peer/local/local.go
@@ -96,11 +96,6 @@ func (m *Manager) HandleAnnouncePeer(ctx context.Context, req *model.AnnounceReq
 	var oldestPeer *common.Peer
 	shouldEject := root.peerMap.Len() > config.AppConfig.Tracker.MaxPeersPerTorrent
 	root.peerMap.Range(func(_ string, value *common.Peer) bool {
-		if time.Now().Add(time.Duration(-1*config.AppConfig.Tracker.TTL) * time.Second).After(value.LastSeen) {
-			// timeout!
-			timeoutPeer = append(timeoutPeer, value)
-			return true
-		}
 		if len(resp) >= req.NumWant {
 			return false
 		}
@@ -114,6 +109,11 @@ func (m *Manager) HandleAnnouncePeer(ctx context.Context, req *model.AnnounceReq
 					oldestPeer = value
 				}
 			}
+		}
+		if time.Now().Add(time.Duration(-1*config.AppConfig.Tracker.TTL) * time.Second).After(value.LastSeen) {
+			// timeout!
+			timeoutPeer = append(timeoutPeer, value)
+			return true
 		}
 		resp = append(resp, value)
 		return true

--- a/biz/services/peer/local/local.go
+++ b/biz/services/peer/local/local.go
@@ -128,7 +128,7 @@ func (m *Manager) HandleAnnouncePeer(ctx context.Context, req *model.AnnounceReq
 			}
 		}()
 	}
-	if shouldEject {
+	if shouldEject && oldestPeer != nil {
 		go func() {
 			hlog.CtxDebugf(ctx, "info hash %s eject %s:%d(%s) %s, last seen:%s", hex.EncodeToString(conv.UnsafeStringToBytes(root.infoHash)), oldestPeer.GetIP().String(), oldestPeer.Port, oldestPeer.ID, oldestPeer.UserAgent, oldestTime.Format(time.DateTime))
 			_, ok := root.peerMap.LoadAndDelete(oldestPeer.GetKey())


### PR DESCRIPTION
修复下面的 panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x48dac4]

goroutine 1107013 [running]:
github.com/PBH-BTN/trunker/biz/services/peer/common.(*Peer).GetIP(...)
        /home/ghost/trunker/biz/services/peer/common/peer.go:59
github.com/PBH-BTN/trunker/biz/services/peer/local.(*Manager).HandleAnnouncePeer.func5()
        /home/ghost/trunker/biz/services/peer/local/local.go:133 +0x134
created by github.com/PBH-BTN/trunker/biz/services/peer/local.(*Manager).HandleAnnouncePeer in goroutine 1085754
        /home/ghost/trunker/biz/services/peer/local/local.go:132 +0xa08
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了在处理旧节点时可能出现的空指针解引用问题，确保只有在存在有效的旧节点时才会执行驱逐逻辑。
	- 调整了节点超时处理逻辑，确保在执行驱逐逻辑之前正确处理超时节点。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->