### PR TITLE
自定义 persistFile 位置

### DIFF
--- a/biz/config/init.go
+++ b/biz/config/init.go
@@ -33,6 +33,7 @@ type TrackerConfig struct {
 	IntervalTask        int64  `yaml:"intervalTask"`
 	UseDB               bool   `yaml:"useDB"`
 	EnablePersist       bool   `yaml:"enablePersist"`
+	PersistFile         string `yaml:"persistFile"`
 	MaxPeersPerTorrent  int    `yaml:"maxPeersPerTorrent"`
 	Shard               int    `yaml:"shard"`
 	UseUnixSocket       bool   `yaml:"useUnixSocket"`

--- a/biz/services/peer/mux_local/persist.go
+++ b/biz/services/peer/mux_local/persist.go
@@ -16,15 +16,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const PersistDataName = "persist.dat"
-
 func (m *MuxLocalManager) LoadFromPersist() {
 	if !config.AppConfig.Tracker.EnablePersist {
 		logger.Info("persist not enabled, skip...")
 		return
 	}
 	logger.Info("start to load peers from persist")
-	file, err := os.OpenFile(PersistDataName, os.O_RDONLY, 0644)
+	file, err := os.OpenFile(config.AppConfig.Tracker.PersistFile, os.O_RDONLY, 0644)
 	if err != nil {
 		logger.Error("open file error:", err.Error())
 		return
@@ -98,7 +96,7 @@ func (m *MuxLocalManager) StoreToPersist() {
 		logger.Info("persist not enabled, skip...")
 		return
 	}
-	file, err := os.OpenFile(PersistDataName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(config.AppConfig.Tracker.PersistFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		logger.Error("open file error")
 		return

--- a/conf/local.yaml
+++ b/conf/local.yaml
@@ -14,6 +14,7 @@ tracker:
   intervalTask: 600 # 10分钟执行一次定时任务
   useDB: false
   enablePersist: true
+  persistFile: persist.dat
   maxPeersPerTorrent: 1500
   shard: 40
   useUnixSocket: false

--- a/conf/prod.yaml
+++ b/conf/prod.yaml
@@ -14,6 +14,7 @@ tracker:
   intervalTask: 600 # 10分钟执行一次定时任务
   useDB: false
   enablePersist: false
+  persistFile: persist.dat
   maxPeersPerTorrent: 1500
   shard: 40
   useUnixSocket: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为跟踪器配置添加了持久化文件路径选项
	- 现在可以在配置文件中自定义持久化数据存储文件名

- **配置更新**
	- 在 `local.yaml` 和 `prod.yaml` 配置文件中新增 `persistFile` 配置
	- 默认持久化文件名为 `persist.dat`

- **改进**
	- 增加了持久化文件位置的灵活性
	- 允许在不同环境中动态配置持久化文件路径

<!-- end of auto-generated comment: release notes by coderabbit.ai -->