### PR TITLE
暂时禁用 external ip 响应字段

### DIFF
--- a/biz/handler/announce.go
+++ b/biz/handler/announce.go
@@ -13,7 +13,6 @@ import (
 	"github.com/PBH-BTN/trunker/utils"
 	"github.com/PBH-BTN/trunker/utils/bencode"
 	"github.com/PBH-BTN/trunker/utils/bittorrent"
-	"github.com/PBH-BTN/trunker/utils/conv"
 	"github.com/PBH-BTN/trunker/utils/http"
 	"github.com/bytedance/gopkg/lang/fastrand"
 	"github.com/cloudwego/hertz/pkg/app"
@@ -72,16 +71,16 @@ func Announce(ctx context.Context, c *app.RequestContext) {
 			Peers: utils.Map(res, func(p *common.Peer) *model.Peer {
 				return p.ToModel()
 			}),
-			ExternalIp: conv.UnsafeBytesToString(req.ClientIP),
+			//ExternalIp: conv.UnsafeBytesToString(req.ClientIP),
 			Incomplete: scrape.Incomplete,
 			Complete:   scrape.Complete,
 		})
 	} else {
 		resp := hertz.H{
-			"interval":    config.AppConfig.Tracker.TTL + int64(fastrand.Intn(201)-100),
-			"external ip": conv.UnsafeBytesToString(req.ClientIP),
-			"incomplete":  scrape.Incomplete,
-			"complete":    scrape.Complete,
+			"interval": config.AppConfig.Tracker.TTL + int64(fastrand.Intn(201)-100),
+			//"external ip": conv.UnsafeBytesToString(req.ClientIP),
+			"incomplete": scrape.Incomplete,
+			"complete":   scrape.Complete,
 		}
 		peers, peers6 := common.PeersToCompact(res)
 		resp["peers"] = peers

--- a/biz/model/http.go
+++ b/biz/model/http.go
@@ -52,9 +52,9 @@ type Peer struct {
 }
 
 type AnnounceBasicResponse struct {
-	Interval   int64    `json:"interval" bencode:"interval"`
-	Peers      []*Peer  `json:"peers" bencode:"peers"`
-	ExternalIp string   `json:"externalIp" bencode:"external ip"`
+	Interval int64   `json:"interval" bencode:"interval"`
+	Peers    []*Peer `json:"peers" bencode:"peers"`
+	//ExternalIp string   `json:"externalIp" bencode:"external ip"`
 	Complete   int      `json:"complete" bencode:"complete"`
 	Incomplete int      `json:"incomplete" bencode:"incomplete"`
 	Offers     []*Offer `json:"offers,omitempty" bencode:"offers,omitempty"`


### PR DESCRIPTION
newTrackon 似乎不能很好的理解这个字段，Tracker 提交不上去，先禁用掉。

对于客户端来说，还有 DHT/PeX 也可以用来探测自身 IP 地址。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 公告响应已进行优化，外部 IP 地址信息已被移除，相关转换处理也已禁用。其他关键响应数据保持不变，本次调整旨在简化数据结构并提升响应的清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->