### PR TITLE
添加对热门 PeerID 的快速检查

### DIFF
--- a/utils/bittorrent/peer_id.go
+++ b/utils/bittorrent/peer_id.go
@@ -20,6 +20,9 @@ func ParsePeerID(peerIdRaw string) string {
 	peerId := strings.TrimFunc(peerIdRaw, func(r rune) bool {
 		return unicode.MaxASCII < r
 	})
+	if strings.HasPrefix(peerId, "-XL0019") {
+		return "-XL0019" // 这是一个 trick，但是考虑到 2900 的请求中有 2100 都是迅雷贡献的，这个改动非常值得，允许这个方法快速返回而无需进行正则判断。
+	}
 	if strings.HasPrefix(peerId, "-FD51") { //-FD51]�-FdrWCsIvJAk4
 		return "-FD51"
 	}


### PR DESCRIPTION
通过 Grafana 图表可以看到目前 Trunker 的流量超过 90% 都是迅雷（-XL0019）贡献的。

这个 PR 通过为 XL0019 添加与 FD 相同的前缀检查，以便在大部分情况下快速返回而无需执行相对较慢的正则匹配。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 系统现已针对部分具有特定标识的客户端请求进行了优化，新增了快速响应机制，从而加快了处理速度，提升了体验。
  - 其他请求流程将继续保持原有稳定性和兼容性，确保整体系统运行平稳。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->